### PR TITLE
Add /user/stats endpoint for dashboard integration

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -64,6 +64,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
 # Import and include routers
 from app.routes import admin, auth, global_data, health, permits, external, supabase_auth
+from app.routes.user import router as user_router
 from app.routers.notification_router import router as notification_router
 
 app.include_router(admin.router, prefix="/admin")
@@ -73,6 +74,7 @@ app.include_router(health.router, prefix="/health")
 app.include_router(permits.router, prefix="/permits")
 app.include_router(external.router, prefix="/external")
 app.include_router(supabase_auth.router, prefix="/auth")
+app.include_router(user_router, prefix="/user")
 app.include_router(notification_router)
 
 @app.get("/")


### PR DESCRIPTION
- Add UserStatsResponse model
- Implement GET /user/stats endpoint that returns:
  * total_calls: Total API calls across all user keys
  * monthly_calls: API calls in last 30 days
  * quota: User's API quota (default 5000)
  * active_keys: Number of active API keys
  * last_activity: Timestamp of last API usage
- Register user router in main.py with /user prefix
- Endpoint requires authentication via JWT token